### PR TITLE
Changed COLLADA files to use Y_UP instead of Z_UP

### DIFF
--- a/jaco_model/meshes/finger_distal_limb_1.dae
+++ b/jaco_model/meshes/finger_distal_limb_1.dae
@@ -8,7 +8,7 @@
     <created>2015-03-25T11:39:55</created>
     <modified>2015-03-25T11:39:55</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/jaco_model/meshes/finger_distal_limb_2.dae
+++ b/jaco_model/meshes/finger_distal_limb_2.dae
@@ -8,7 +8,7 @@
     <created>2015-03-25T11:39:55</created>
     <modified>2015-03-25T11:39:55</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/jaco_model/meshes/finger_proximal_limb_1.dae
+++ b/jaco_model/meshes/finger_proximal_limb_1.dae
@@ -8,7 +8,7 @@
     <created>2015-03-24T18:14:15</created>
     <modified>2015-03-24T18:14:15</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/jaco_model/meshes/finger_proximal_limb_2.dae
+++ b/jaco_model/meshes/finger_proximal_limb_2.dae
@@ -8,7 +8,7 @@
     <created>2015-03-24T18:32:38</created>
     <modified>2015-03-24T18:32:38</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_cameras>
     <camera id="Camera-camera" name="Camera">

--- a/jaco_model/meshes/mico_link_1.dae
+++ b/jaco_model/meshes/mico_link_1.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:18:03</created>
     <modified>2014-12-29T11:18:03</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_2.dae
+++ b/jaco_model/meshes/mico_link_2.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:25:07</created>
     <modified>2014-12-29T11:25:07</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_3.dae
+++ b/jaco_model/meshes/mico_link_3.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:28:10</created>
     <modified>2014-12-29T11:28:10</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_4.dae
+++ b/jaco_model/meshes/mico_link_4.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:44:28</created>
     <modified>2014-12-29T11:44:28</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_5.dae
+++ b/jaco_model/meshes/mico_link_5.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:44:28</created>
     <modified>2014-12-29T11:44:28</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_base.dae
+++ b/jaco_model/meshes/mico_link_base.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T11:10:21</created>
     <modified>2014-12-29T11:10:21</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>

--- a/jaco_model/meshes/mico_link_hand.dae
+++ b/jaco_model/meshes/mico_link_hand.dae
@@ -8,7 +8,7 @@
     <created>2014-12-29T12:38:52</created>
     <modified>2014-12-29T12:38:52</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
+    <up_axis>Y_UP</up_axis>
   </asset>
   <library_images/>
   <library_geometries>


### PR DESCRIPTION
This pull request changes `up_axis` from `Z_UP` in the COLLADA meshes to `Y_UP`. Assimp introduces an incorrect root transformation when loading meshes that do not use `Y_UP`. This does not affect RViz because it [includes a hack to specifically deal with this bug](https://github.com/ros-visualization/rviz/blob/cd691c5d3244b868b0aade4b84c59344c35156d0/src/rviz/mesh_loader.cpp#L228), but it does affect other programs that use Assimp for asset loading prior to this change (e.g. OpenRAVE).

I've verified that this does not change the appearance of the Mico's collision or visual geometry in RViz.

For example, here is what `mico_standalone.urdf.xacro` looks like in OpenRAVE without this change:

![Mico with Z_UP in OpenRAVE](https://cloud.githubusercontent.com/assets/142251/7873273/479812ae-056e-11e5-9272-b1be2cfafe14.png)